### PR TITLE
add replicator and the chunk accessor

### DIFF
--- a/golibs/sss/inmem/storage.go
+++ b/golibs/sss/inmem/storage.go
@@ -16,6 +16,7 @@ package inmem
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"github.com/solarisdb/solaris/golibs/errors"
 	"github.com/solarisdb/solaris/golibs/sss"
@@ -41,7 +42,7 @@ func NewStorage() *Storage {
 
 // Get allows to read a value by its key. If key is not found the
 // ErrNotExist should be returned
-func (st *Storage) Get(key string) (io.ReadCloser, error) {
+func (st *Storage) Get(_ context.Context, key string) (io.ReadCloser, error) {
 	if !sss.IsKeyValid(key) {
 		return nil, fmt.Errorf("Storage.Get(): invalid key=%s", key)
 	}
@@ -54,7 +55,7 @@ func (st *Storage) Get(key string) (io.ReadCloser, error) {
 }
 
 // Put allows to store value represented by reader r by the key
-func (st *Storage) Put(key string, r io.Reader) error {
+func (st *Storage) Put(_ context.Context, key string, r io.Reader) error {
 	if !sss.IsKeyValid(key) {
 		return fmt.Errorf("Storage.Put(): invalid key=%s", key)
 	}
@@ -76,7 +77,7 @@ func (st *Storage) Put(key string, r io.Reader) error {
 // for the keys list: "/abc", "/def/abc", "/def/aa1"
 // List("/") -> "/abc", "/def/"
 // List("/def/") -> "/def/abc", "/def/aa1"
-func (st *Storage) List(path string) ([]string, error) {
+func (st *Storage) List(_ context.Context, path string) ([]string, error) {
 	if !sss.IsPathValid(path) {
 		return nil, fmt.Errorf("Storage.List(): invalid path=%s", path)
 	}
@@ -102,12 +103,15 @@ func (st *Storage) List(path string) ([]string, error) {
 }
 
 // Delete allows to delete a value by key. If the key doesn't exist, the operation
-// will return no error
-func (st *Storage) Delete(key string) error {
+// will return no errors.ErrNotExist
+func (st *Storage) Delete(_ context.Context, key string) error {
 	if !sss.IsKeyValid(key) {
 		return fmt.Errorf("Storage.Delete(): invalid key=%s", key)
 	}
 
+	if _, ok := st.storage[key]; !ok {
+		return errors.ErrNotExist
+	}
 	delete(st.storage, key)
 	return nil
 }

--- a/golibs/sss/service.go
+++ b/golibs/sss/service.go
@@ -18,6 +18,7 @@ sss package stays for Simple Storage Service which provides an interface to the 
 package sss
 
 import (
+	"context"
 	"io"
 	"strings"
 )
@@ -45,10 +46,10 @@ import (
 type Storage interface {
 	// Get allows to read a value by its key. If key is not found the
 	// ErrNotExist should be returned
-	Get(key string) (io.ReadCloser, error)
+	Get(ctx context.Context, key string) (io.ReadCloser, error)
 
 	// Put allows to store value represented by reader r by the key
-	Put(key string, r io.Reader) error
+	Put(ctx context.Context, key string, r io.Reader) error
 
 	// List returns a list of keys and sub-paths (part of an existing path which
 	// is a path itself), which have the prefix of the path argument
@@ -57,11 +58,11 @@ type Storage interface {
 	// for the keys list: "/abc", "/def/abc", "/def/aa1"
 	// List("/") -> "/abc", "/def/"
 	// List("/def/") -> "/def/abc", "/def/aa1"
-	List(path string) ([]string, error)
+	List(ctx context.Context, path string) ([]string, error)
 
 	// Delete allows to delete a value by key. If the key doesn't exist, the operation
 	// will return no error
-	Delete(key string) error
+	Delete(ctx context.Context, key string) error
 }
 
 // IsKeyValid checks whether the key is valid: <path><keysuffix> where the keysuffix is a string without '/'

--- a/golibs/sss/tstsuite.go
+++ b/golibs/sss/tstsuite.go
@@ -15,6 +15,7 @@
 package sss
 
 import (
+	"context"
 	"github.com/solarisdb/solaris/golibs/errors"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
@@ -29,76 +30,76 @@ func TestSimpleStorage(t *testing.T, ss Storage) {
 	data2 := "value2"
 
 	// wrong key
-	err := ss.Put("aaa/", strings.NewReader(data1))
+	err := ss.Put(context.Background(), "aaa/", strings.NewReader(data1))
 	assert.NotNil(t, err)
 
 	// populate
-	err = ss.Put("/val1", strings.NewReader(data1))
+	err = ss.Put(context.Background(), "/val1", strings.NewReader(data1))
 	assert.Nil(t, err)
-	err = ss.Put("/val2", strings.NewReader(data1))
+	err = ss.Put(context.Background(), "/val2", strings.NewReader(data1))
 	assert.Nil(t, err)
-	err = ss.Put("/val2", strings.NewReader(data2))
-	assert.Nil(t, err)
-
-	err = ss.Put("/subfldr/val3", strings.NewReader(data1))
-	assert.Nil(t, err)
-	err = ss.Put("/subfldr/val4", strings.NewReader(data1))
+	err = ss.Put(context.Background(), "/val2", strings.NewReader(data2))
 	assert.Nil(t, err)
 
-	err = ss.Put("/subfldr/subfldr2/val4", strings.NewReader(data1))
+	err = ss.Put(context.Background(), "/subfldr/val3", strings.NewReader(data1))
+	assert.Nil(t, err)
+	err = ss.Put(context.Background(), "/subfldr/val4", strings.NewReader(data1))
+	assert.Nil(t, err)
+
+	err = ss.Put(context.Background(), "/subfldr/subfldr2/val4", strings.NewReader(data1))
 	assert.Nil(t, err)
 
 	// wrong path
-	_, err = ss.List("")
+	_, err = ss.List(context.Background(), "")
 	assert.NotNil(t, err)
 
-	res, err := ss.List("/")
+	res, err := ss.List(context.Background(), "/")
 	assert.Nil(t, err)
 	sort.Strings(res)
 	assert.Equal(t, []string{"/subfldr/", "/val1", "/val2"}, res)
 
-	res, err = ss.List("/subfldr/")
+	res, err = ss.List(context.Background(), "/subfldr/")
 	assert.Nil(t, err)
 	sort.Strings(res)
 	assert.Equal(t, []string{"/subfldr/subfldr2/", "/subfldr/val3", "/subfldr/val4"}, res)
 
-	r, err := ss.Get("/val2")
+	r, err := ss.Get(context.Background(), "/val2")
 	assert.Nil(t, err)
 	buf, _ := ioutil.ReadAll(r)
 	assert.Equal(t, data2, string(buf))
 
-	r, err = ss.Get("/subfldr/val3")
+	r, err = ss.Get(context.Background(), "/subfldr/val3")
 	assert.Nil(t, err)
 	buf, _ = ioutil.ReadAll(r)
 	assert.Equal(t, data1, string(buf))
 
-	_, err = ss.Get("/val3")
+	_, err = ss.Get(context.Background(), "/val3")
 	assert.NotNil(t, err)
 	assert.Equal(t, errors.ErrNotExist, err)
 
 	// deleting
-	ss.Delete("/subfldr/val3")
-	ss.Delete("/subfldr/val3")
-	res, err = ss.List("/subfldr/")
+	ss.Delete(context.Background(), "/subfldr/val3")
+	ss.Delete(context.Background(), "/subfldr/val3")
+	res, err = ss.List(context.Background(), "/subfldr/")
 	assert.Nil(t, err)
 	sort.Strings(res)
 	assert.Equal(t, []string{"/subfldr/subfldr2/", "/subfldr/val4"}, res)
 
-	ss.Delete("/subfldr/subfldr2/val4")
+	ss.Delete(context.Background(), "/subfldr/subfldr2/val4")
 
-	ss.Delete("/subfldr/val4")
-	res, err = ss.List("/subfldr/")
+	ss.Delete(context.Background(), "/subfldr/val4")
+	res, err = ss.List(context.Background(), "/subfldr/")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{}, res)
 
-	res, err = ss.List("/")
+	res, err = ss.List(context.Background(), "/")
 	assert.Nil(t, err)
 	sort.Strings(res)
 	assert.Equal(t, []string{"/val1", "/val2"}, res)
 
-	ss.Delete("/val1")
-	ss.Delete("/val2")
-	res, err = ss.List("/")
+	ss.Delete(context.Background(), "/val1")
+	ss.Delete(context.Background(), "/val2")
+	res, err = ss.List(context.Background(), "/")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{}, res)
 }

--- a/pkg/storage/buntdb/buntdb.go
+++ b/pkg/storage/buntdb/buntdb.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Solaris Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package buntdb
 
 import (

--- a/pkg/storage/buntdb/buntdb_test.go
+++ b/pkg/storage/buntdb/buntdb_test.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Solaris Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package buntdb
 
 import (

--- a/pkg/storage/cache/cache.go
+++ b/pkg/storage/cache/cache.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Solaris Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package cache
 
 import (

--- a/pkg/storage/chunkfs/caccessor.go
+++ b/pkg/storage/chunkfs/caccessor.go
@@ -1,0 +1,203 @@
+// Copyright 2024 The Solaris Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunkfs
+
+import (
+	"context"
+	"fmt"
+	"github.com/solarisdb/solaris/golibs/errors"
+	"sync"
+)
+
+type (
+	// chunkAccessor implements a FSM for sharing access to the local chunk files. It keeps the states for every chunk file, and
+	// it serves as a synchronization barrier between Chunk and Replicator objects, that may touch the chunk
+	// files in parallel.
+	chunkAccessor struct {
+		lock   sync.Mutex
+		chunks map[string]*caRec
+		closed bool
+		doneCh chan struct{}
+	}
+
+	caRec struct {
+		state    int
+		opened   bool
+		waiterCh chan struct{}
+	}
+)
+
+const (
+	cStateUnknown  = 0
+	cStateIdle     = 1
+	cStateWriting  = 2
+	cStateDeleting = 3
+)
+
+func newChunkAccessor() *chunkAccessor {
+	return &chunkAccessor{chunks: make(map[string]*caRec), doneCh: make(chan struct{})}
+}
+
+func (cc *chunkAccessor) Close() error {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+	if cc.closed {
+		return nil
+	}
+	cc.closed = true
+	close(cc.doneCh)
+	return nil
+}
+
+func (cc *chunkAccessor) openChunk(ctx context.Context, cID string) error {
+	for {
+		cc.lock.Lock()
+		if cc.closed {
+			cc.lock.Unlock()
+			return errors.ErrClosed
+		}
+		cr, ok := cc.chunks[cID]
+		if !ok {
+			cr = &caRec{state: cStateIdle}
+			cc.chunks[cID] = cr
+		}
+		if cr.state == cStateDeleting {
+			cc.lock.Unlock()
+			return fmt.Errorf("raise: open while deleting %v: %w", cr, errors.ErrNotExist)
+		}
+		if cr.opened {
+			cc.lock.Unlock()
+			return fmt.Errorf("unaccepted state in openChunk() %v: %w", cr, errors.ErrInternal)
+		}
+		cr.opened = true
+		if cr.state == cStateIdle {
+			// it seems just created, we are fine then
+			cc.lock.Unlock()
+			return nil
+		}
+		ch := cr.getWaiterCh()
+		cc.lock.Unlock()
+
+		select {
+		case <-ctx.Done():
+			cc.closeChunk(cID)
+			return ctx.Err()
+		case <-cc.doneCh:
+			cc.closeChunk(cID)
+			return errors.ErrClosed
+		case <-ch:
+			// ok, let's try again
+			cc.closeChunk(cID)
+		}
+	}
+}
+
+func (cc *chunkAccessor) setWriting(ctx context.Context, cID string) error {
+	for {
+		cc.lock.Lock()
+		if cc.closed {
+			cc.lock.Unlock()
+			return errors.ErrClosed
+		}
+		cr, ok := cc.chunks[cID]
+		if !ok {
+			cr = &caRec{state: cStateWriting}
+			cc.chunks[cID] = cr
+			cc.lock.Unlock()
+			return nil
+		}
+		if cr.state == cStateIdle {
+			cr.setState(cStateWriting)
+			cc.lock.Unlock()
+			return nil
+		}
+		if cr.state == cStateDeleting {
+			cc.lock.Unlock()
+			return fmt.Errorf("the chunk file is being deleted: %w", errors.ErrNotExist)
+		}
+		ch := cr.getWaiterCh()
+		cc.lock.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-cc.doneCh:
+			return errors.ErrClosed
+		case <-ch:
+			// ok, let's try again
+		}
+	}
+}
+
+// setDeleting tries to set Deleting state, and it returns true if successlul. It will return false otherwise.
+func (cc *chunkAccessor) setDeleting(cID string) bool {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+	if cc.closed {
+		return false
+	}
+	cr, ok := cc.chunks[cID]
+	if !ok {
+		cr = &caRec{state: cStateDeleting}
+		cc.chunks[cID] = cr
+	}
+	return !ok
+}
+
+func (cc *chunkAccessor) setIdle(cID string) {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+	cr, ok := cc.chunks[cID]
+	if !ok {
+		return
+	}
+	cr.setState(cStateIdle)
+	if !cr.opened {
+		delete(cc.chunks, cID)
+	}
+}
+
+func (cc *chunkAccessor) closeChunk(cID string) error {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+	cr, ok := cc.chunks[cID]
+	if !ok || !cr.opened {
+		return errors.ErrClosed
+	}
+	cr.opened = false
+	if cr.state == cStateIdle {
+		cr.setState(cStateUnknown) // do this to notify waiters if any
+		delete(cc.chunks, cID)
+	}
+	return nil
+}
+
+func (cr *caRec) setState(newState int) {
+	if cr.state == newState {
+		return
+	}
+	cr.state = newState
+	if cr.waiterCh != nil {
+		close(cr.waiterCh)
+		cr.waiterCh = nil
+	}
+}
+
+func (cr *caRec) getWaiterCh() chan struct{} {
+	if cr.waiterCh == nil {
+		cr.waiterCh = make(chan struct{})
+	}
+	return cr.waiterCh
+}

--- a/pkg/storage/chunkfs/caccessor_test.go
+++ b/pkg/storage/chunkfs/caccessor_test.go
@@ -1,0 +1,142 @@
+// Copyright 2024 The Solaris Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunkfs
+
+import (
+	"context"
+	"github.com/solarisdb/solaris/golibs/errors"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestChunkAccessor_OpenChunk(t *testing.T) {
+	ca := newChunkAccessor()
+
+	assert.Nil(t, ca.openChunk(context.Background(), "ll"))
+	assert.NotNil(t, ca.openChunk(context.Background(), "ll"))
+	assert.Nil(t, ca.closeChunk("ll"))
+	assert.Nil(t, ca.openChunk(context.Background(), "ll"))
+
+	assert.Nil(t, ca.closeChunk("ll"))
+	assert.True(t, ca.setDeleting("ll"))
+	assert.NotNil(t, ca.openChunk(context.Background(), "ll"))
+	ca.setIdle("ll")
+	assert.Nil(t, ca.openChunk(context.Background(), "ll"))
+
+	assert.Nil(t, ca.closeChunk("ll"))
+	ca.setWriting(context.Background(), "ll")
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		ca.setIdle("ll")
+	}()
+	assert.Nil(t, ca.openChunk(context.Background(), "ll"))
+	assert.NotNil(t, ca.openChunk(context.Background(), "ll"))
+
+	assert.Nil(t, ca.closeChunk("ll"))
+	ca.setWriting(context.Background(), "ll")
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := ca.openChunk(ctx, "ll")
+	assert.Equal(t, ctx.Err(), err)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		ca.Close()
+	}()
+	assert.True(t, errors.ErrClosed == ca.openChunk(context.Background(), "ll"))
+	assert.True(t, errors.ErrClosed == ca.openChunk(context.Background(), "ll"))
+}
+
+func TestChunkAccessor_SetWriting(t *testing.T) {
+	ca := newChunkAccessor()
+
+	assert.Nil(t, ca.setWriting(context.Background(), "ll"))
+	ca.setIdle("ll")
+	assert.Nil(t, ca.openChunk(context.Background(), "ll"))
+	assert.Nil(t, ca.setWriting(context.Background(), "ll"))
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		ca.setIdle("ll")
+	}()
+	assert.Nil(t, ca.setWriting(context.Background(), "ll"))
+
+	ca.setIdle("ll")
+	assert.Nil(t, ca.closeChunk("ll"))
+	assert.Nil(t, ca.setWriting(context.Background(), "ll"))
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		ca.setIdle("ll")
+	}()
+	assert.Nil(t, ca.setWriting(context.Background(), "ll"))
+	ca.setIdle("ll")
+	assert.Equal(t, 0, len(ca.chunks))
+
+	ca.setWriting(context.Background(), "ll")
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := ca.setWriting(ctx, "ll")
+	assert.Equal(t, ctx.Err(), err)
+	ca.setIdle("ll")
+
+	// check the waiting channel
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			assert.Nil(t, ca.setWriting(context.Background(), "l1"))
+			ca.setIdle("l1")
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	assert.Nil(t, ca.setWriting(context.Background(), "ll"))
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		ca.Close()
+	}()
+	assert.True(t, errors.ErrClosed == ca.setWriting(context.Background(), "ll"))
+	assert.True(t, errors.ErrClosed == ca.setWriting(context.Background(), "ll"))
+}
+
+func TestChunkAccessor_SetDeleting(t *testing.T) {
+	ca := newChunkAccessor()
+	assert.True(t, ca.setDeleting("ll"))
+	assert.False(t, ca.setDeleting("ll"))
+	ca.setIdle("ll")
+	assert.True(t, ca.setDeleting("ll"))
+	ca.setIdle("ll")
+
+	ca.Close()
+	assert.False(t, ca.setDeleting("ll"))
+}
+
+func TestChunkAccessor_SetIdle(t *testing.T) {
+	ca := newChunkAccessor()
+
+	ca.setWriting(context.Background(), "l1")
+	ca.openChunk(context.Background(), "l2")
+	ca.Close()
+	assert.Equal(t, 2, len(ca.chunks))
+	ca.setIdle("l1")
+	ca.setIdle("l2")
+	assert.Equal(t, 1, len(ca.chunks))
+	assert.NotNil(t, ca.closeChunk("l1"))
+	assert.Nil(t, ca.closeChunk("l2"))
+	assert.Equal(t, 0, len(ca.chunks))
+}

--- a/pkg/storage/chunkfs/chunk.go
+++ b/pkg/storage/chunkfs/chunk.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package chunkfs
 
 import (

--- a/pkg/storage/chunkfs/provider_test.go
+++ b/pkg/storage/chunkfs/provider_test.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Solaris Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package chunkfs
 
 import (

--- a/pkg/storage/chunkfs/replicator.go
+++ b/pkg/storage/chunkfs/replicator.go
@@ -1,0 +1,205 @@
+// Copyright 2024 The Solaris Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunkfs
+
+import (
+	"context"
+	"fmt"
+	"github.com/solarisdb/solaris/golibs/errors"
+	"github.com/solarisdb/solaris/golibs/files"
+	"github.com/solarisdb/solaris/golibs/logging"
+	"github.com/solarisdb/solaris/golibs/sss"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Replicator struct implements the object which controls the state of the local file-system and allows to move
+// the chunks from the local FS to a remote storage forth and back.
+type Replicator struct {
+	cc           *chunkAccessor
+	fileNameByID func(id string) string
+	storage      sss.Storage
+	logger       logging.Logger
+}
+
+const (
+	RFRemoteDelete = 1
+	RFRemoteSync   = 1 << 1
+)
+
+// UploadChunk moves the chunk with ID from the local FS to the remote storage.
+func (r *Replicator) UploadChunk(ctx context.Context, cID string) error {
+	if err := r.cc.setWriting(ctx, cID); err != nil {
+		return err
+	}
+	defer r.cc.setIdle(cID)
+	return r.zipAndUploadChunk(ctx, cID)
+}
+
+// DownloadChunk allows to download the chunk by its ID from the remote storage to the local FS.
+// The RFRemoteSync flag specifies whether the chunk will be downloaded even if the chunk file already
+// exists on the file system. If the chunk file doesn't exist locally, it will be downloaded anyway from the
+// remote storage
+func (r *Replicator) DownloadChunk(ctx context.Context, cID string, flags int) error {
+	if err := r.cc.setWriting(ctx, cID); err != nil {
+		return err
+	}
+	defer r.cc.setIdle(cID)
+
+	fn := r.fileNameByID(cID)
+	if flags&RFRemoteSync == 0 {
+		if _, err := os.Stat(fn); err == nil {
+			// the file is here, do nothing then
+			return nil
+		}
+	}
+
+	r.logger.Debugf("downolading chunk cID=%s from remote storage", cID)
+	zfn := fn + ".zip"
+	defer os.Remove(zfn)
+	if err := r.downloadZip(ctx, cID, zfn); err != nil {
+		return err
+	}
+	return r.unzip(zfn, fn)
+}
+
+// DeleteChunk allows to delete the chunk locally. The function may upload the chunk to the remote storage
+// before being deleted (the flags&RFRemoteSync != 0), or to remove the chunk locally only (no flags required) and
+// remove it locally and remotely (flags&RFRemoteDelete != 0)
+func (r *Replicator) DeleteChunk(ctx context.Context, cID string, flags int) error {
+	if flags&RFRemoteDelete != 0 && flags&RFRemoteSync != 0 {
+		return fmt.Errorf("the flags RFRemoteDelete and RFRemoteSync cannot be specified both when a chunk is removed. cID=%s: %w", cID, errors.ErrInvalid)
+	}
+	if ok := r.cc.setDeleting(cID); !ok {
+		return fmt.Errorf("the chunk cID=%s, is used and cannot be deleted at the time: %w", cID, errors.ErrConflict)
+	}
+	defer r.cc.setIdle(cID)
+	r.logger.Debugf("deleting chunk cID=%s, flags=%d", cID, flags)
+	var resErr error
+	if flags&RFRemoteSync != 0 {
+		if err := r.zipAndUploadChunk(ctx, cID); err != nil {
+			r.logger.Warnf("error while syncing chunk cID=%s, flags=%d to remote: %s", cID, flags, err)
+			resErr = err
+		}
+	}
+
+	fn := r.fileNameByID(cID)
+	if err := os.Remove(fn); err != nil && !errors.Is(err, errors.ErrNotExist) {
+		r.logger.Warnf("error while deleting cID=%s, fn=%s: %s", cID, fn, err)
+		resErr = err
+	}
+
+	if flags&RFRemoteDelete != 0 {
+		err := r.storage.Delete(ctx, getStorageKey(cID))
+		if err != nil {
+			r.logger.Warnf("could not delete the chunk cID=%s remotely: %s", cID, err)
+			resErr = err
+		}
+	}
+
+	return resErr
+}
+
+func (r *Replicator) zipAndUploadChunk(ctx context.Context, cID string) error {
+	fn := r.fileNameByID(cID)
+	zfn := fn + ".zip"
+	defer os.Remove(zfn)
+
+	if err := zipFile(cID, fn, zfn); err != nil {
+		return err
+	}
+
+	// now the zip file itself
+	zf, err := os.Open(zfn)
+	if err != nil {
+		return err
+	}
+	defer zf.Close()
+
+	return r.storage.Put(ctx, getStorageKey(cID), zf)
+}
+
+func zipFile(cID, fn, zfn string) error {
+	zw, err := files.NewZipWriter(zfn)
+	if err != nil {
+		return err
+	}
+	defer zw.Close()
+
+	// the chunk file
+	f, err := os.Open(fn)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// writer to the zip file
+	w, err := zw.Create(cID)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(w, f); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getStorageKey(cID string) string {
+	return filepath.Join("/", cID[len(cID)-2:], cID)
+}
+
+func (r *Replicator) downloadZip(ctx context.Context, cID, zfn string) error {
+	rdr, err := r.storage.Get(ctx, getStorageKey(cID))
+	if err != nil {
+		return err
+	}
+	defer rdr.Close()
+
+	f, err := os.Create(zfn)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, rdr)
+	return err
+}
+
+func (r *Replicator) unzip(zfn, fn string) error {
+	zit, err := files.NewZipIterator(zfn)
+	if err != nil {
+		return err
+	}
+	defer zit.Close()
+
+	zf := zit.Next()
+	if zf == nil {
+		return fmt.Errorf("the downloaded chunk for the file=%s is corrupted: %w", zfn, errors.ErrDataLoss)
+	}
+	it, err := zf.Open()
+	if err != nil {
+		return err
+	}
+	defer it.Close()
+
+	_ = os.Remove(fn)
+	f, err := os.Create(fn)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, it)
+	return err
+}

--- a/pkg/storage/chunkfs/replicator_test.go
+++ b/pkg/storage/chunkfs/replicator_test.go
@@ -1,0 +1,136 @@
+// Copyright 2024 The Solaris Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunkfs
+
+import (
+	"context"
+	"github.com/solarisdb/solaris/golibs/cast"
+	"github.com/solarisdb/solaris/golibs/errors"
+	"github.com/solarisdb/solaris/golibs/logging"
+	"github.com/solarisdb/solaris/golibs/sss/inmem"
+	"github.com/solarisdb/solaris/golibs/strutil"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplicator_SimpleUploadDownload(t *testing.T) {
+	dir, err := os.MkdirTemp("", "TestReplicator_SimpleUploadDownload")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	r := &Replicator{cc: newChunkAccessor(), storage: inmem.NewStorage(), logger: logging.NewLogger("testReplicator"), fileNameByID: func(v string) string {
+		return filepath.Join(dir, v)
+	}}
+
+	cID := "1234"
+	fn := r.fileNameByID(cID)
+	payload := createRandomFile(t, fn)
+	assert.Nil(t, r.UploadChunk(context.Background(), cID))
+	os.Remove(r.fileNameByID(cID))
+
+	// check the chunk accessor
+	r.cc.setDeleting(cID)
+	assert.NotNil(t, r.DownloadChunk(context.Background(), cID, 0))
+	r.cc.setIdle(cID)
+
+	// will check that the file will be downloaded if it doesn't exist
+	assert.Nil(t, r.DownloadChunk(context.Background(), cID, 0))
+	buf, err := os.ReadFile(fn)
+	assert.Nil(t, err)
+	assert.Equal(t, buf, cast.StringToByteArray(payload))
+
+	// will check that if the file exists, it will not be downloaded
+	// create the new context
+	os.Remove(fn)
+	createRandomFile(t, fn)
+	assert.Nil(t, r.DownloadChunk(context.Background(), cID, 0))
+	buf, err = os.ReadFile(fn)
+	assert.Nil(t, err)
+	assert.NotEqual(t, buf, cast.StringToByteArray(payload))
+
+	// now force sync
+	assert.Nil(t, r.DownloadChunk(context.Background(), cID, RFRemoteSync))
+	buf, err = os.ReadFile(fn)
+	assert.Nil(t, err)
+	assert.Equal(t, buf, cast.StringToByteArray(payload))
+
+	assert.True(t, errors.Is(r.DownloadChunk(context.Background(), "lslsl", RFRemoteSync), errors.ErrNotExist))
+}
+
+func TestReplicator_SimpleDelete(t *testing.T) {
+	dir, err := os.MkdirTemp("", "TestReplicator_SimpleDelete")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	r := &Replicator{cc: newChunkAccessor(), storage: inmem.NewStorage(), logger: logging.NewLogger("testReplicator"), fileNameByID: func(v string) string {
+		return filepath.Join(dir, v)
+	}}
+
+	cID := "1234"
+	fn := r.fileNameByID(cID)
+	payload := createRandomFile(t, fn)
+	assert.Nil(t, r.UploadChunk(context.Background(), cID))
+
+	// check the chunk accessory
+	r.cc.openChunk(context.Background(), cID)
+	assert.NotNil(t, r.DeleteChunk(context.Background(), cID, 0))
+	assert.Nil(t, r.cc.closeChunk(cID))
+
+	// not both flags
+	assert.NotNil(t, r.DeleteChunk(context.Background(), cID, RFRemoteDelete|RFRemoteSync))
+	_, err = os.Stat(fn)
+	assert.Nil(t, err)
+
+	// delete locally, but upload it remotely
+	assert.Nil(t, r.DeleteChunk(context.Background(), cID, RFRemoteSync))
+	_, err = os.Stat(fn)
+	assert.True(t, errors.Is(err, errors.ErrNotExist))
+	assert.Nil(t, r.DownloadChunk(context.Background(), cID, 0))
+	buf, err := os.ReadFile(fn)
+	assert.Nil(t, err)
+	assert.Equal(t, buf, cast.StringToByteArray(payload))
+
+	// delete locally only
+	assert.Nil(t, r.DeleteChunk(context.Background(), cID, 0))
+	_, err = os.Stat(fn)
+	assert.True(t, errors.Is(err, errors.ErrNotExist))
+
+	// could not delete deleted
+	assert.NotNil(t, r.DeleteChunk(context.Background(), cID, RFRemoteSync))
+
+	// check the file exists remotely
+	assert.Nil(t, r.DownloadChunk(context.Background(), cID, 0))
+	buf, err = os.ReadFile(fn)
+	assert.Nil(t, err)
+	assert.Equal(t, buf, cast.StringToByteArray(payload))
+
+	// delete everywhere
+	assert.Nil(t, r.DeleteChunk(context.Background(), cID, RFRemoteDelete))
+	assert.NotNil(t, r.DownloadChunk(context.Background(), cID, 0))
+
+	assert.NotNil(t, r.DeleteChunk(context.Background(), cID, RFRemoteDelete))
+}
+
+func createRandomFile(t *testing.T, fn string) string {
+	f, err := os.Create(fn)
+	assert.Nil(t, err)
+	defer f.Close()
+	s := strutil.RandomString(512)
+	_, err = f.Write(cast.StringToByteArray(s))
+	assert.Nil(t, err)
+	return s
+}


### PR DESCRIPTION
This is the first PR in the series of adding the S3 replication mechanism. Two things added so far:
- chunk accessor is the component which separates the access to the chunk files on the file system. In case of some manipulations with the chunk file, no other components which uses the chunk accessor may use the file at the time. This component will be used by the chunkfs.Chunk and the Replicator to control access to the file on the file-system
- Replicator is the component which allows to upload, download and delete the chunk files either locally or remotely. It compresses the chunk file for storing it in the remote storage. 

What is not here but comming:
- the Scanner - a component which will scan the local file storage and either run the remote upload, download or clean up the local FS if there is no available space. 