### PR TITLE
fix a wrong attemp of deleting a non empty chunk

### DIFF
--- a/pkg/storage/logfs/locallog.go
+++ b/pkg/storage/logfs/locallog.go
@@ -156,6 +156,7 @@ func (l *localLog) AppendRecords(ctx context.Context, request *solaris.AppendRec
 			cis = append(cis, ci)
 			recs = recs[arr.Written:]
 			added += arr.Written
+			ci.ID = ""
 		} else if ci.RecordsCount == 0 {
 			// the chunk was just created and its capacity is not enough to write at least one record!
 			gerr = fmt.Errorf("it seems the maximum chunk size is less than the record size payload=%d: %w", len(recs[0].Payload), errors.ErrInvalid)


### PR DESCRIPTION
After all records were  added to a last chunk, its copy is changed with RecordsCount = 0 for allowing to create a new chunk. Then the code tries to delete an empty chunk, and so it tries to delete chunk with real ID. Really this attempt fails because there is a check on file size, but in any way this issue spawns a lot of ERRORs in logs.