### PR TITLE
add db connection limits for postgres

### DIFF
--- a/pkg/db/config.go
+++ b/pkg/db/config.go
@@ -1,0 +1,39 @@
+package db
+
+import "fmt"
+
+// DBConn represents database connection parameters
+type DBConn struct {
+	// Driver is the db driver (e.g. postgres)
+	Driver string
+	// Host is the host address where the db reside
+	Host string
+	// Port is the port on which the db is listening for connections
+	Port string
+	// Username is the username for authc/z against the db
+	Username string
+	// Password is the password for authc/z against the db
+	Password string
+	// DBName is the name of the db to connect to
+	DBName string
+	// SSLMode is the SSL mode to use
+	SSLMode string
+	// MaxConnections is the max number of open connections to db
+	MaxConnections *int
+	// MaxIdleConnections is the max number of idle connections to db
+	MaxIdleConnections *int
+	// MaxConnIdleTimeSec is the duration (in seconds) while idle connections will be alive and available for reusing
+	MaxConnIdleTimeSec *int
+}
+
+// SourceName returns the DSN for the connection
+func (d *DBConn) SourceName() string {
+	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		d.Host, d.Port, d.Username, d.Password, d.DBName, d.SSLMode)
+}
+
+// URL returns the URL for the connection
+func (d *DBConn) URL() string {
+	return fmt.Sprintf("%s://%s:%s@%s:%s/%s?sslmode=%s",
+		d.Driver, d.Username, d.Password, d.Host, d.Port, d.DBName, d.SSLMode)
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -17,9 +17,11 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/solarisdb/solaris/golibs/cast"
 	"github.com/solarisdb/solaris/golibs/config"
 	"github.com/solarisdb/solaris/golibs/logging"
 	"github.com/solarisdb/solaris/golibs/transport"
+	"github.com/solarisdb/solaris/pkg/db"
 )
 
 type (
@@ -30,44 +32,14 @@ type (
 		// HttpPort defines the port for listening incoming HTTP connections
 		HttpPort int
 		// DB specifies DBConn for storing the logs and chunks metadata
-		DB *DBConn
+		DB *db.DBConn
 		// LocalDBFilePath specifies where the logs data is stored
 		LocalDBFilePath string
 		// MaxOpenedLogFiles allows to control number of files opened at a time to work with the solaris data
 		// Increasing the number allows to increase the system performance for accessing to random group of logs
 		MaxOpenedLogFiles int
 	}
-
-	// DBConn represents database connection parameters
-	DBConn struct {
-		// Driver is the db driver (e.g. postgres)
-		Driver string
-		// Host is the host address where the db reside
-		Host string
-		// Port is the port on which the db is listening for connections
-		Port string
-		// Username is the username for authc/z against the db
-		Username string
-		// Password is the password for authc/z against the db
-		Password string
-		// DBName is the name of the db to connect to
-		DBName string
-		// SSLMode is the SSL mode to use
-		SSLMode string
-	}
 )
-
-// SourceName returns the DSN for the connection
-func (d *DBConn) SourceName() string {
-	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
-		d.Host, d.Port, d.Username, d.Password, d.DBName, d.SSLMode)
-}
-
-// URL returns the URL for the connection
-func (d *DBConn) URL() string {
-	return fmt.Sprintf("%s://%s:%s@%s:%s/%s?sslmode=%s",
-		d.Driver, d.Username, d.Password, d.Host, d.Port, d.DBName, d.SSLMode)
-}
 
 // getDefaultConfig returns the default server config
 func getDefaultConfig() *Config {
@@ -76,14 +48,17 @@ func getDefaultConfig() *Config {
 		HttpPort:          8080,
 		LocalDBFilePath:   "slogs",
 		MaxOpenedLogFiles: 100,
-		DB: &DBConn{
-			Driver:   "postgres",
-			Host:     "localhost",
-			Port:     "5432",
-			Username: "postgres",
-			Password: "postgres",
-			DBName:   "solaris",
-			SSLMode:  "disable",
+		DB: &db.DBConn{
+			Driver:             "postgres",
+			Host:               "localhost",
+			Port:               "5432",
+			Username:           "postgres",
+			Password:           "postgres",
+			DBName:             "solaris",
+			SSLMode:            "disable",
+			MaxConnections:     cast.Ptr(64),
+			MaxIdleConnections: cast.Ptr(64),
+			MaxConnIdleTimeSec: cast.Ptr(30),
 		},
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -67,7 +67,7 @@ func Run(ctx context.Context, cfg *Config) error {
 	replicator := chunkfs.NewReplicator(provider.GetFileNameByID)
 
 	// Db
-	db := postgres.MustGetDb(ctx, cfg.DB.SourceName())
+	db := postgres.MustGetDb(ctx, cfg.DB)
 
 	inj := linker.New()
 	inj.Register(linker.Component{Name: "", Value: cache.NewCachedStorage(postgres.NewStorage(db))})

--- a/pkg/storage/postgres/testsuite.go
+++ b/pkg/storage/postgres/testsuite.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/jmoiron/sqlx"
+	"github.com/solarisdb/solaris/pkg/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"time"
@@ -68,7 +69,7 @@ func (ts *pgTestSuite) BeforeTest(suiteName, testName string) {
 	assert.Nil(ts.T(), ts.dropCreatePgDb(ctx))
 
 	var err error
-	ts.db, err = GetDb(ctx, dbCfg.DataSourceFull())
+	ts.db, err = GetDb(ctx, toDbConn(dbCfg))
 	assert.Nil(ts.T(), err)
 	assert.Nil(ts.T(), ts.db.Init(ctx))
 }
@@ -96,4 +97,16 @@ func (ts *pgTestSuite) dropCreatePgDb(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func toDbConn(cfg DbConfig) *db.DBConn {
+	return &db.DBConn{
+		Driver:   "postgres",
+		DBName:   cfg.DbName,
+		Host:     cfg.Host,
+		Port:     cfg.Port,
+		Username: cfg.User,
+		Password: cfg.Password,
+		SSLMode:  cfg.SslMode,
+	}
 }


### PR DESCRIPTION
During a test with many clients an issue with connections to Postgres was found. As a solution, new db conn params for limiting db connections could be added. Following changes are proposed:
-Add MaxConnections, MaxIdleConnections, MaxConnIdleTimeSec params to DBConn
-Move DBConn to a separate package for avoiding cyclic imports
-Apply new params on  connect to Postgres